### PR TITLE
Support v1.2/requests API, add new fields

### DIFF
--- a/lib/uber/api/requests.rb
+++ b/lib/uber/api/requests.rb
@@ -10,28 +10,28 @@ module Uber
     module Requests
       def trip_estimate(*args)
         arguments = Uber::Arguments.new(args)
-        perform_with_object(:post, "v1/requests/estimate", arguments.options, Estimate)
+        perform_with_object(:post, "v1.2/requests/estimate", arguments.options, Estimate)
       end
 
       def trip_request(*args)
         arguments = Uber::Arguments.new(args)
-        perform_with_object(:post, "v1/requests", arguments.options, Request)
+        perform_with_object(:post, "v1.2/requests", arguments.options, Request)
       end
 
       def trip_details(request_id)
-        perform_with_object(:get, "v1/requests/#{request_id}", {}, Request)
+        perform_with_object(:get, "v1.2/requests/#{request_id}", {}, Request)
       end
 
       def trip_map(request_id)
-        perform_with_object(:get, "v1/requests/#{request_id}/map", {}, Map)
+        perform_with_object(:get, "v1.2/requests/#{request_id}/map", {}, Map)
       end
 
       def trip_update(request_id, status)
-        perform_with_object(:put, "v1/sandbox/requests/#{request_id}", {status: status}, Request)
+        perform_with_object(:put, "v1.2/sandbox/requests/#{request_id}", {status: status}, Request)
       end
 
       def trip_cancel(request_id)
-        perform_with_object(:delete, "v1/requests/#{request_id}", {}, Request)
+        perform_with_object(:delete, "v1.2/requests/#{request_id}", {}, Request)
       end
 
       def trip_receipt(request_id)

--- a/lib/uber/models/request.rb
+++ b/lib/uber/models/request.rb
@@ -59,6 +59,6 @@ module Uber
   end
 
   class Location < Base
-    attr_accessor :alias, :address, :bearing, :eta, :latitude, :longitude, :nickname
+    attr_accessor :alias, :address, :bearing, :eta, :latitude, :longitude, :name
   end
 end

--- a/lib/uber/models/request.rb
+++ b/lib/uber/models/request.rb
@@ -59,6 +59,6 @@ module Uber
   end
 
   class Location < Base
-    attr_accessor :latitude, :longitude, :bearing, :eta
+    attr_accessor :alias, :address, :bearing, :eta, :latitude, :longitude, :nickname
   end
 end

--- a/spec/lib/api/requests_spec.rb
+++ b/spec/lib/api/requests_spec.rb
@@ -7,7 +7,7 @@ describe Uber::API::Requests do
   describe '#trip_estimate' do
     context 'with a valid response' do
       before do
-        stub_uber_request(:post, "v1/requests/estimate",
+        stub_uber_request(:post, "v1.2/requests/estimate",
                           # From: https://developer.uber.com/docs/v1-requests-estimate
                           {
                             "price" => {
@@ -54,7 +54,7 @@ describe Uber::API::Requests do
   describe '#trip_request' do
     context 'with a valid response' do
       before do
-        stub_uber_request(:post, "v1/requests",
+        stub_uber_request(:post, "v1.2/requests",
                           # From: https://developer.uber.com/v1/endpoints/#request
                           {
                             "status" => "accepted",
@@ -109,7 +109,7 @@ describe Uber::API::Requests do
         let!(:sandbox_client) { setup_client(sandbox: true) }
 
         before do
-          stub_uber_request(:post, "v1/requests",
+          stub_uber_request(:post, "v1.2/requests",
                             # From: https://developer.uber.com/v1/endpoints/#request
                             {
                               "status" => "accepted",
@@ -165,7 +165,7 @@ describe Uber::API::Requests do
 
     context 'with a "processing" response' do
       before do
-        stub_uber_request(:post, "v1/requests",
+        stub_uber_request(:post, "v1.2/requests",
                           # From: https://developer.uber.com/v1/endpoints/#request
                           {
                             :status => "processing",
@@ -195,7 +195,7 @@ describe Uber::API::Requests do
 
     context 'with a 409 conflict with surge response' do
       before do
-        stub_uber_request(:post, "v1/requests",
+        stub_uber_request(:post, "v1.2/requests",
                           # From: https://developer.uber.com/v1/endpoints/#request
                           {
                             "meta" => {
@@ -232,7 +232,7 @@ describe Uber::API::Requests do
 
   describe '#trip_details' do
     before do
-      stub_uber_request(:get, "v1/requests/deadbeef",
+      stub_uber_request(:get, "v1.2/requests/deadbeef",
                         # From: https://developer.uber.com/v1/endpoints/#request-details
                         {
                           "status" => "accepted",
@@ -303,7 +303,7 @@ describe Uber::API::Requests do
 
   describe '#trip_map' do
     before do
-      stub_uber_request(:get, "v1/requests/deadbeef/map",
+      stub_uber_request(:get, "v1.2/requests/deadbeef/map",
                         # From: https://developer.uber.com/v1/endpoints/#request-map
                         {
                           "request_id" => "b5512127-a134-4bf4-b1ba-fe9f48f56d9d",
@@ -322,7 +322,7 @@ describe Uber::API::Requests do
     let!(:sandbox_client) { setup_client(sandbox: true) }
 
     before do
-      stub_uber_request(:put, "v1/sandbox/requests/deadbeef",
+      stub_uber_request(:put, "v1.2/sandbox/requests/deadbeef",
                         # From: https://developer.uber.com/v1/sandbox/
                         nil,
                         body: {status: 'accepted'}.to_json,
@@ -340,7 +340,7 @@ describe Uber::API::Requests do
     let!(:sandbox_client) { setup_client(sandbox: true) }
 
     before do
-      stub_uber_request(:delete, "v1/requests/deadbeef",
+      stub_uber_request(:delete, "v1.2/requests/deadbeef",
                         # From: https://developer.uber.com/docs/v1-requests-cancel
                         nil,
                         body: {},

--- a/spec/lib/api/requests_spec.rb
+++ b/spec/lib/api/requests_spec.rb
@@ -249,14 +249,20 @@ describe Uber::API::Requests do
                             "bearing" => 33
                           },
                           "pickup" => {
+                            "address" => "742 Evergreen Terrace",
+                            "alias" => "home",
+                            "eta" => 5,
                             "latitude" => 0.0,
                             "longitude" => 0.5,
-                            "eta" => 5
+                            "name" => "742 Evergreen",
                           },
                           "destination" => {
+                            "address" => "123 Fake Street",
+                            "alias" => "work",
+                            "eta" => 19,
                             "latitude" => 0.0,
                             "longitude" => 0.6,
-                            "eta" => 19
+                            "name" => "123 Fake",
                           },
                           "vehicle" => {
                             "make" => "Bugatti",
@@ -286,13 +292,19 @@ describe Uber::API::Requests do
       expect(request.location.longitude).to eql -122.418143
       expect(request.location.bearing).to eql 33
 
+      expect(request.pickup.address).to eql "742 Evergreen Terrace"
+      expect(request.pickup.alias).to eql "home"
+      expect(request.pickup.eta).to eql 5
       expect(request.pickup.latitude).to eql 0.0
       expect(request.pickup.longitude).to eql 0.5
-      expect(request.pickup.eta).to eql 5
+      expect(request.pickup.name).to eql "742 Evergreen"
 
+      expect(request.destination.address).to eql "123 Fake Street"
+      expect(request.destination.alias).to eql "work"
+      expect(request.destination.eta).to eql 19
       expect(request.destination.latitude).to eql 0.0
       expect(request.destination.longitude).to eql 0.6
-      expect(request.destination.eta).to eql 19
+      expect(request.destination.name).to eql "123 Fake"
 
       expect(request.vehicle.make).to eql 'Bugatti'
       expect(request.vehicle.model).to eql 'Veyron'


### PR DESCRIPTION
This updates `Uber::API::Requests` to use the newer `v1.2/requests` API so we have access to the `alias`, `address`, and `name` properties of pickup and destination `Location`s outlined here: https://developer.uber.com/docs/riders/references/api/v1.2/requests-post.

The docs are a little inconsistent since these fields were just added; it's unclear, for example, if `name` or `nickname` is correct, since we have seen examples using `name` from Uber but `nickname` is used in the doc above.

Though these fields aren't super dependable _yet_, we can start building against them with a fall back to our existing behavior. When `alias` is set to `home` or `work`, for example, we can skip the work we do currently to geocode and match pickup/destination to `home` and `work` from the Rider's profile.

@anhqpham @chaslemley does this look ok? We can't open this PR against upstream quite yet since most of the details of these APIs were shared privately.

/cc @lmcarter621 